### PR TITLE
Locales Numberformat parsing Double

### DIFF
--- a/src/Main/Interface_Main.java
+++ b/src/Main/Interface_Main.java
@@ -154,7 +154,10 @@ public class Interface_Main extends javax.swing.JFrame {
                     //String elementData = serialData.get(i).toString();
                     //String splits[] = elementData.split(":");
                     Gson gson = new GsonBuilder().create();
-                    USBTester usbtester = gson.fromJson(serialData.get(i).toString(), USBTester.class);
+                    USBTester usbtester =new USBTester();
+		    try {
+		    usbtester = gson.fromJson(serialData.get(i).toString(),
+								USBTester.class);
                     
                     /*
                     System.out.println(usbtester);
@@ -185,15 +188,12 @@ public class Interface_Main extends javax.swing.JFrame {
                     //Double voltage = Double.parseDouble(splits[3]);
                     
                     Locale myLocale = Locale.getDefault();
-		    NumberFormat f = NumberFormat.getInstance(myLocale);
+		    NumberFormat.getInstance(myLocale);
 		    DecimalFormat twoDForm = new DecimalFormat("#.##");
 		    Double WattageFTemp= ((current / 1000) * voltage);
-		    try {
+		   
 		    twoDForm.parse(twoDForm.format(WattageFTemp));
-		    } catch (ParseException e) {
-		    e.printStackTrace();
-		    }
-
+		   
 		    Double wattage = Double.valueOf(WattageFTemp);
                     //System.out.println("Current:" + current);
                     //System.out.println("Voltage:" + voltage);
@@ -240,7 +240,9 @@ public class Interface_Main extends javax.swing.JFrame {
                                 + "," + usbtester.getDp() + "," + usbtester.getDm()
                                );
                     recSamples++;
-
+                    } catch (Exception e) {
+		    e.printStackTrace();
+		    }
                 }
                 
                 lastSize = serialDataSize;

--- a/src/Main/Interface_Main.java
+++ b/src/Main/Interface_Main.java
@@ -184,9 +184,17 @@ public class Interface_Main extends javax.swing.JFrame {
                     //Double current = Double.parseDouble(splits[4]);
                     //Double voltage = Double.parseDouble(splits[3]);
                     
-                    DecimalFormat twoDForm = new DecimalFormat("#.##");
-                    Double wattage = Double.valueOf(twoDForm.format((current/1000)*voltage));
-                    
+                    Locale myLocale = Locale.getDefault();
+		    NumberFormat f = NumberFormat.getInstance(myLocale);
+		    DecimalFormat twoDForm = new DecimalFormat("#.##");
+		    Double WattageFTemp= ((current / 1000) * voltage);
+		    try {
+		    twoDForm.parse(twoDForm.format(WattageFTemp));
+		    } catch (ParseException e) {
+		    e.printStackTrace();
+		    }
+
+		    Double wattage = Double.valueOf(WattageFTemp);
                     //System.out.println("Current:" + current);
                     //System.out.println("Voltage:" + voltage);
                     //System.out.println("Wattage:" + wattage);

--- a/src/Main/Interface_Main.java
+++ b/src/Main/Interface_Main.java
@@ -44,6 +44,8 @@ import java.io.OutputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.text.DecimalFormat;
+import java.text.NumberFormat;
+import java.util.Locale;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.imageio.ImageIO;


### PR DESCRIPTION
Fix Error with Different Double Values"0,00","0.00"

Example:

```
Locale[] locales = NumberFormat.getAvailableLocales();
    double myNumber = -1234.56;
    NumberFormat form;
    for (int j=0; j<4; ++j) {
        System.out.println("FORMAT");
        for (int i = 0; i < locales.length; ++i) {
            if (locales[i].getCountry().length() == 0) {
               continue; // Skip language-only locales
            }
            System.out.print(locales[i].getDisplayName());
            switch (j) {
            case 0:
                form = NumberFormat.getInstance(locales[i]); break;
            case 1:
                form = NumberFormat.getIntegerInstance(locales[i]); break;
            case 2:
                form = NumberFormat.getCurrencyInstance(locales[i]); break;
            default:
                form = NumberFormat.getPercentInstance(locales[i]); break;
            }
            if (form instanceof DecimalFormat) {
                System.out.print(": " + ((DecimalFormat) form).toPattern());
            }
            System.out.print(" -> " + form.format(myNumber));
            try {
                System.out.println(" -> " + form.parse(form.format(myNumber)));
            } catch (ParseException e) {}
        }
    }
```
